### PR TITLE
Add in clonePath so that all directories can have intellisense

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,6 +1,12 @@
 apiVersion: 1.0.0
 metadata:
   generateName: aoc2020
+projects:
+  - name: advent-of-code-2020
+    source:
+      location: 'https://github.com/che-incubator/advent-of-code-2020.git'
+      type: git
+    clonePath: src/github.com/che-incubator/advent-of-code-2020
 components:
   - alias: tools
     type: dockerimage


### PR DESCRIPTION
Currently, as it stands, I can't seem to get intellisense working OOTB. The way I've done it so far is just to create a `go.mod` file in the root of the project. However, when I do this intellisense is only working for the first go file I open (and none of the others). This PR fixes that by putting advent-of-code-2020 in `src/github.com/che-incubator/` so that all go files will have intellisense in the project

Signed-off-by: jpinkney-1 <jpinkney@redhat.com>